### PR TITLE
config: only allow dependabot updates for internal modules + security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,8 @@ version: 2
 updates:
   - package-ecosystem: "gomod"
     directory: "/"
+    allow:
+      - dependency-name: github.com/palavrapasse*
     schedule:
       interval: "daily"
       time: "20:00"


### PR DESCRIPTION
we'll still receive security updates after enabling it in https://github.com/palavrapasse/santos/settings/security_analysis
